### PR TITLE
Bumps the base image to ubi8/openjdk-11:1.10-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN ./gradlew assemble copyJarToServerJar --no-daemon
 
 
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-15
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.10-1
 
 ## Uncomment the lines below to update image security content if any
 # USER root


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>